### PR TITLE
Fix Bash Variable Assignment in choose_color Step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
         elif ((80 > ${{ inputs.coverage }} && ${{ inputs.coverage }} >= 60)); then
           COLOR="yellow"
         elif ((60 > ${{ inputs.coverage }} && ${{ inputs.coverage }} >= 0)); then
-          COLOR ="red"
+          COLOR="red"
         else
           exit 1
         fi


### PR DESCRIPTION
# Fix Bash Variable Assignment in choose_color Step

## Description
This PR fixes a bug in the `choose_color` step where the Bash variable assignment had an extra space (`COLOR ="red"`), which caused a syntax error. The correct assignment is now `COLOR="red"`.

## Changes
- Fixed incorrect Bash variable assignment in `action.yml`.

## Impact
- Ensures the script correctly assigns the color for coverage badges.
- Prevents syntax errors in GitHub Actions workflows.

## Checklist
- [x] Fix Bash variable assignment
- [x] Tested the workflow successfully
- [x] Ready for review
